### PR TITLE
Check if xarray dataset by trying xr.open_zarr

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,9 @@
+v0.2.2 (2021-03-28)
+-------------------
+
+- change implementation for checking whether object is an xarray dataset
+- apply black formatting
+
 v0.2.1 (2020-11-26)
 -------------------
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,19 +41,17 @@ def tmp_zarr_group(tmpdir):
 @pytest.mark.parametrize("consolidated", [True, False])
 def test__open_with_xarray_or_zarr_on_zarr_group(tmp_zarr_group, consolidated):
     group, path = tmp_zarr_group(consolidated=consolidated)
-    opened_group, is_xarray_dataset = _open_with_xarray_or_zarr(
-        fsspec.get_mapper(path), consolidated
-    )
+    m = fsspec.get_mapper(path)
+    opened_group, is_xarray_dataset = _open_with_xarray_or_zarr(m, consolidated)
     np.testing.assert_allclose(group["var1"], opened_group["var1"])
-    assert not (is_xarray_dataset)
+    assert not is_xarray_dataset
 
 
 @pytest.mark.parametrize("consolidated", [True, False])
 def test__open_with_xarray_or_zarr_on_xarray_ds(tmp_xarray_ds, consolidated):
     ds, path = tmp_xarray_ds(consolidated=consolidated)
-    opened_ds, is_xarray_dataset = _open_with_xarray_or_zarr(
-        fsspec.get_mapper(path), consolidated
-    )
+    m = fsspec.get_mapper(path)
+    opened_ds, is_xarray_dataset = _open_with_xarray_or_zarr(m, consolidated)
     np.testing.assert_allclose(ds["var1"], opened_ds["var1"])
     assert is_xarray_dataset
 

--- a/zarrdump/__init__.py
+++ b/zarrdump/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.1'
+__version__ = "0.2.1"
 
 from .core import dump

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -15,14 +15,8 @@ def dump(url: str, variable: str):
         raise click.ClickException(f"No file or directory at {url}")
 
     m = fs.get_mapper(url)
-    zarr_obj, consolidated = _open_zarr(m)
-
-    if _zarr_object_is_xarray_dataset(zarr_obj):
-        printme = xr.open_zarr(m, consolidated=consolidated)
-        object_is_xarray = True
-    else:
-        printme = zarr_obj
-        object_is_xarray = False
+    consolidated = _metadata_is_consolidated(m)
+    printme, object_is_xarray = _open_with_xarray_or_zarr(m, consolidated)
 
     if variable is not None:
         printme = printme[variable]
@@ -33,27 +27,24 @@ def dump(url: str, variable: str):
     print(printme)
 
 
-def _open_zarr(m: fsspec.FSMap) -> Union[zarr.hierarchy.Group, zarr.core.Array]:
+def _metadata_is_consolidated(m: fsspec.FSMap) -> bool:
     try:
-        result = zarr.open_consolidated(m)
+        zarr.open_consolidated(m)
         consolidated = True
     except KeyError:
-        # un-consolidated group, or array
-        result = zarr.open(m)
+        # group with un-consolidated metadata, or array
         consolidated = False
+    return consolidated
 
-    return result, consolidated
 
-
-def _zarr_object_is_xarray_dataset(
-    obj: Union[zarr.hierarchy.Group, zarr.core.Array]
-) -> bool:
+def _open_with_xarray_or_zarr(
+    m: fsspec.FSMap, consolidated: bool
+) -> Union[xr.Dataset, zarr.hierarchy.Group, zarr.core.Array]:
     try:
-        array_keys = list(obj.keys())
-    except AttributeError:
+        result = xr.open_zarr(m, consolidated=consolidated)
+        is_xarray_dataset = True
+    except KeyError:
+        # xarray requires _ARRAY_DIMENSIONS attribute, assuming missing if KeyError
+        result = zarr.open_consolidated(m) if consolidated else zarr.open(m)
         is_xarray_dataset = False
-    else:
-        array = obj[array_keys[0]]
-        required_xarray_attr = xr.backends.zarr.DIMENSION_KEY
-        is_xarray_dataset = True if required_xarray_attr in array.attrs else False
-    return is_xarray_dataset
+    return result, is_xarray_dataset

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -39,7 +39,7 @@ def _metadata_is_consolidated(m: fsspec.FSMap) -> bool:
 
 def _open_with_xarray_or_zarr(
     m: fsspec.FSMap, consolidated: bool
-) -> Union[xr.Dataset, zarr.hierarchy.Group, zarr.core.Array]:
+) -> Tuple[Union[xr.Dataset, zarr.hierarchy.Group, zarr.core.Array], bool]:
     try:
         result = xr.open_zarr(m, consolidated=consolidated)
         is_xarray_dataset = True

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Tuple, Union
 
 import click
 import fsspec

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -36,18 +36,18 @@ def dump(url: str, variable: str):
 def _open_zarr(m: fsspec.FSMap) -> Union[zarr.hierarchy.Group, zarr.core.Array]:
     try:
         result = zarr.open_consolidated(m)
-        consolidated=True
+        consolidated = True
     except KeyError:
         # un-consolidated group, or array
         result = zarr.open(m)
-        consolidated=False
+        consolidated = False
 
     return result, consolidated
 
 
 def _zarr_object_is_xarray_dataset(
     obj: Union[zarr.hierarchy.Group, zarr.core.Array]
-    ) -> bool:
+) -> bool:
     try:
         array_keys = list(obj.keys())
     except AttributeError:


### PR DESCRIPTION
Instead of explicitly checking for existence of `xr.backends.zarr.DIMENSION_KEY` within array attributes, just try opening mapper with `xr.open_zarr` and use `zarr` if a `KeyError` gets raised.

Resolves #4.