### PR TITLE
Ensure dumping zarr group works w/ xarray 2022.06.0

### DIFF
--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -55,7 +55,7 @@ def _open_with_xarray_or_zarr(
     try:
         result = xr.open_zarr(m, consolidated=consolidated)
         is_xarray_dataset = True
-    except KeyError:
+    except (KeyError, TypeError):
         # xarray requires _ARRAY_DIMENSIONS attribute, assuming missing if KeyError
         result = zarr.open_consolidated(m) if consolidated else zarr.open(m)
         is_xarray_dataset = False


### PR DESCRIPTION
Need to except TypeError now instead of KeyError.