### PR TITLE
Add support for zarr-python 3.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,7 +29,7 @@ jobs:
           if [[ "$PYTHON_VERSION" == "3.9"* ]]; then
             echo "Detected Python version: $PYTHON_VERSION"
             echo "Skipping tests with xarray versions that require newer python"
-            tox -p --skip-env xarray202501
+            tox -p --skip-env py-xarray202501
           else
             tox -p
           fi

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,8 +20,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest tox
+          pip install tox
           pip install -e .
       - name: Test with tox
         run: |
-          tox -p
+          PYTHON_VERSION=$(python --version | cut -d' ' -f2)
+          
+          if [[ "$PYTHON_VERSION" == "3.9"* ]]; then
+            echo "Detected Python version: $PYTHON_VERSION"
+            echo "Skipping tests with xarray versions that require newer python"
+            tox -p --skip-env xarray202501
+          else
+            tox -p
+          fi

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,11 @@
+latest
+------
+
+- add support for zarr-python>=3.0.0
+- drop support for xarray<0.19.0
+- defer to xarray/zarr for handling consolidated metadata
+
+
 v0.4.2 (2025-01-20)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "zarr>=2.3.0",
 ]
 
-test_requirements = ["pytest"]
+test_requirements = ["pytest", "gcsfs"]
 
 setup(
     author="Oliver Watt-Meyer",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "click>=7.0.0",
     "fsspec>=0.7.0",
-    "xarray>=0.15.0",
+    "xarray>=0.19.0",
     "zarr>=2.3.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "zarr>=2.3.0",
 ]
 
-test_requirements = ["pytest", "gcsfs"]
+test_requirements = ["pytest"]
 
 setup(
     author="Oliver Watt-Meyer",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "click>=7.0.0",
     "fsspec>=0.7.0",
     "xarray>=0.15.0",
-    "zarr>=2.3.0,<3",
+    "zarr>=2.3.0",
 ]
 
 test_requirements = ["pytest"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,7 +100,6 @@ def test_dump_max_rows_default(tmp_xarray_ds):
     assert len(result.output.split("\n")) > 30
 
 
-@pytest.mark.skipif(xr.__version__ < "0.18.0", reason="need xarray v0.18.0 or higher")
 def test_dump_max_rows_limited(tmp_xarray_ds):
     runner = CliRunner()
     _, path = tmp_xarray_ds(consolidated=True, n_vars=30)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,3 +116,16 @@ def test_dump_max_rows_limited(tmp_xarray_ds):
     _, path = tmp_xarray_ds(consolidated=True, n_vars=30)
     result = runner.invoke(dump, [path, "-m", 10])
     assert len(result.output.split("\n")) < 20  # give some buffer over 10
+
+
+def test_dump_executes_on_google_cloud_storage_url():
+    """This test uses a public dataset on GCS which could disappear at any time.
+    
+    Feel free to delete if it starts failing.
+    """
+    runner = CliRunner()
+    url = "gs://cmip6/CMIP6/ScenarioMIP/NCAR/CESM2/ssp245/r1i1p1f1/Amon/tas/gn/v20190730"
+    result = runner.invoke(dump, [url])
+    assert result.exit_code == 0
+    assert "<xarray.Dataset>" in result.output
+    assert "Dimensions:" in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,8 @@ import xarray as xr
 import zarr
 
 
-ZARR_MAJOR_VERSION = zarr.__version__.split('.')[0]
+ZARR_MAJOR_VERSION = zarr.__version__.split(".")[0]
+
 
 def test_version():
     assert zarrdump.__version__ == "0.4.2"
@@ -55,6 +56,7 @@ def test__metadata_is_consolidated_on_zarr(tmp_zarr_group, consolidated):
 def test__metadata_is_consolidated_on_xarray(tmp_xarray_ds, consolidated):
     _, path = tmp_xarray_ds(consolidated=consolidated)
     assert consolidated == _metadata_is_consolidated(path)
+
 
 @pytest.mark.parametrize("consolidated", [True, False])
 def test__open_with_xarray_or_zarr_on_zarr_group(tmp_zarr_group, consolidated):
@@ -116,16 +118,3 @@ def test_dump_max_rows_limited(tmp_xarray_ds):
     _, path = tmp_xarray_ds(consolidated=True, n_vars=30)
     result = runner.invoke(dump, [path, "-m", 10])
     assert len(result.output.split("\n")) < 20  # give some buffer over 10
-
-
-def test_dump_executes_on_google_cloud_storage_url():
-    """This test uses a public dataset on GCS which could disappear at any time.
-    
-    Feel free to delete if it starts failing.
-    """
-    runner = CliRunner()
-    url = "gs://cmip6/CMIP6/ScenarioMIP/NCAR/CESM2/ssp245/r1i1p1f1/Amon/tas/gn/v20190730"
-    result = runner.invoke(dump, [url])
-    assert result.exit_code == 0
-    assert "<xarray.Dataset>" in result.output
-    assert "Dimensions:" in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@ import zarrdump
 from zarrdump.core import dump, _open_with_xarray_or_zarr
 
 from click.testing import CliRunner
-import fsspec
 import pytest
 import numpy as np
 import xarray as xr

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -75,6 +75,10 @@ def test_dump_executes_on_zarr_group(tmp_zarr_group, options):
     _, path = tmp_zarr_group(consolidated=True)
     result = runner.invoke(dump, [path] + options)
     assert result.exit_code == 0
+    if "-v" in options:
+        assert "Array" in result.output
+    else:
+        assert "Group" in result.output
 
 
 @pytest.mark.parametrize("options", [[], ["-v", "var1"], ["--info"]])
@@ -83,6 +87,13 @@ def test_dump_executes_on_xarray_dataset(tmp_xarray_ds, options):
     _, path = tmp_xarray_ds(consolidated=True)
     result = runner.invoke(dump, [path] + options)
     assert result.exit_code == 0
+    if "-v" in options:
+        expected_content = "<xarray.DataArray"
+    elif "--info" in options:
+        expected_content = "xarray.Dataset"
+    else:
+        expected_content = "<xarray.Dataset>"
+    assert expected_content in result.output
 
 
 def test_dump_disallowed_options(tmp_xarray_ds):

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     click
     pytest
     fsspec
-    gcsfs
     xarray16: xarray>=0.16.0,<0.17.0
     xarray19: xarray>=0.19.0,<0.20.0
     xarray21: xarray>=0.21.0,<0.22.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py-xarray{16,19,21,202203,202206,202306,202312,202501}
+envlist = py-xarray{19,21,202203,202206,202306,202312,202501}
 
 [testenv]
 deps =
     click
     pytest
     fsspec
-    xarray16: xarray>=0.16.0,<0.17.0
     xarray19: xarray>=0.19.0,<0.20.0
     xarray21: xarray>=0.21.0,<0.22.0
     xarray202203: xarray>=2022.03.0,<2022.04.0
@@ -19,13 +18,11 @@ deps =
     xarray202306: xarray>=2023.06.0,<2023.07.0
     xarray202312: xarray>=2023.12.0,<2024.01.0
     xarray202501: xarray==2025.01.1
-    xarray16: numpy<2
     xarray19: numpy<2
     xarray21: numpy<2
     xarray202203: numpy<2
     xarray202206: numpy<2
     xarray202306: numpy<2
-    xarray16: zarr<3
     xarray19: zarr<3
     xarray21: zarr<3
     xarray202203: zarr<3

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     click
     pytest
     fsspec
+    gcsfs
     xarray16: xarray>=0.16.0,<0.17.0
     xarray19: xarray>=0.19.0,<0.20.0
     xarray21: xarray>=0.21.0,<0.22.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py-xarray{19,21,202203,202206,202306,202312,202501}
+envlist = py-xarray{19,21,202206,202306,202312,202501}
 
 [testenv]
 deps =
@@ -13,19 +13,16 @@ deps =
     fsspec
     xarray19: xarray>=0.19.0,<0.20.0
     xarray21: xarray>=0.21.0,<0.22.0
-    xarray202203: xarray>=2022.03.0,<2022.04.0
     xarray202206: xarray>=2022.06.0,<2022.07.0
     xarray202306: xarray>=2023.06.0,<2023.07.0
     xarray202312: xarray>=2023.12.0,<2024.01.0
     xarray202501: xarray==2025.01.1
     xarray19: numpy<2
     xarray21: numpy<2
-    xarray202203: numpy<2
     xarray202206: numpy<2
     xarray202306: numpy<2
     xarray19: zarr<3
     xarray21: zarr<3
-    xarray202203: zarr<3
     xarray202206: zarr<3
     xarray202306: zarr<3
     xarray202312: zarr<3

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py-xarray{16,19,21,202203,202206,202306,202312}
+envlist = py-xarray{16,19,21,202203,202206,202306,202312,202501}
 
 [testenv]
 deps =
     click
     pytest
     fsspec
-    zarr
     xarray16: xarray>=0.16.0,<0.17.0
     xarray19: xarray>=0.19.0,<0.20.0
     xarray21: xarray>=0.21.0,<0.22.0
@@ -19,11 +18,20 @@ deps =
     xarray202206: xarray>=2022.06.0,<2022.07.0
     xarray202306: xarray>=2023.06.0,<2023.07.0
     xarray202312: xarray>=2023.12.0,<2024.01.0
+    xarray202501: xarray==2025.01.1
     xarray16: numpy<2
     xarray19: numpy<2
     xarray21: numpy<2
     xarray202203: numpy<2
     xarray202206: numpy<2
     xarray202306: numpy<2
+    xarray16: zarr<3
+    xarray19: zarr<3
+    xarray21: zarr<3
+    xarray202203: zarr<3
+    xarray202206: zarr<3
+    xarray202306: zarr<3
+    xarray202312: zarr<3
+    xarray202501: zarr>=3
 commands =
     pytest

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -31,11 +31,7 @@ def dump(url: str, variable: str, max_rows: int, info: bool):
     if object_is_xarray and info:
         object_.info()
     else:
-        try:
-            with xr.set_options(display_max_rows=max_rows):
-                print(object_)
-        except ValueError:
-            # xarray<v0.18.0 does not have display_max_rows option
+        with xr.set_options(display_max_rows=max_rows):
             print(object_)
 
 

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -51,7 +51,7 @@ def _metadata_is_consolidated(m: fsspec.FSMap) -> bool:
 
 def _open_with_xarray_or_zarr(
     m: fsspec.FSMap, consolidated: bool
-) -> Tuple[Union[xr.Dataset, zarr.hierarchy.Group, zarr.core.Array], bool]:
+) -> Tuple[Union[xr.Dataset, zarr.Group, zarr.Array], bool]:
     try:
         result = xr.open_zarr(m, consolidated=consolidated)
         is_xarray_dataset = True

--- a/zarrdump/core.py
+++ b/zarrdump/core.py
@@ -39,7 +39,9 @@ def _open_with_xarray_or_zarr(
     url: str,
 ) -> Tuple[Union[xr.Dataset, zarr.Group, zarr.Array], bool]:
     if ZARR_MAJOR_VERSION >= "3":
-        exceptions = (ValueError,)
+        # TODO: remove ValueError here once a version of xarray is released
+        # with https://github.com/pydata/xarray/pull/10025 merged
+        exceptions = (KeyError, ValueError)
     else:
         exceptions = (KeyError, TypeError)
 


### PR DESCRIPTION
- add support for zarr-python>=3
- drop support for xarray<0.19.0
- defer to xarray/zarr for handling whether metadata is consolidated or not. This may lead to additional warnings in the case of non-consolidated metadata. Performance may also be slower when dumping metadata associated with a pure zarr (not xarray-openable) dataset and using zarr-python<3.